### PR TITLE
Refine secret scanning allowlist

### DIFF
--- a/.github/workflows/secret-scanning.yml
+++ b/.github/workflows/secret-scanning.yml
@@ -186,9 +186,10 @@ jobs:
             '''placeholder[_-]?value''',
             '''your[_-]?api[_-]?key[_-]?here''',
             '''replace[_-]?with[_-]?actual''',
-            '''TODO:.*''',
-            '''FIXME:.*''',
-            '''XXX:.*'''
+            # Allow simple TODO/FIXME/XXX comments without quoted values
+            '''TODO:[^"'=]*$''',
+            '''FIXME:[^"'=]*$''',
+            '''XXX:[^"'=]*$'''
           ]
           EOF
           fi

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -40,7 +40,8 @@ regexes = [
   '''placeholder[_-]?value''',
   '''your[_-]?api[_-]?key[_-]?here''',
   '''replace[_-]?with[_-]?actual''',
-  '''TODO:.*''',
-  '''FIXME:.*''',
-  '''XXX:.*'''
+  # Allow simple TODO/FIXME/XXX comments without quoted values
+  '''TODO:[^"'=]*$''',
+  '''FIXME:[^"'=]*$''',
+  '''XXX:[^"'=]*$'''
 ]

--- a/config/.gitleaks.toml
+++ b/config/.gitleaks.toml
@@ -62,9 +62,10 @@ regexes = [
   '''placeholder[_-]?value''',
   '''your[_-]?api[_-]?key[_-]?here''',
   '''replace[_-]?with[_-]?actual''',
-  '''TODO:.*''',
-  '''FIXME:.*''',
-  '''XXX:.*''',
+  # Allow simple TODO/FIXME/XXX comments without quoted values
+  '''TODO:[^"'=]*$''',
+  '''FIXME:[^"'=]*$''',
+  '''XXX:[^"'=]*$''',
   '''localhost''',
   '''127\.0\.0\.1''',
   '''0\.0\.0\.0''',

--- a/docs/cicd/README.md
+++ b/docs/cicd/README.md
@@ -99,6 +99,20 @@ id = "governance-secret"
 regex = '''(?i)(governance[_-]?secret|constitutional[_-]?key)['"]*\s*[:=]\s*['"][a-zA-Z0-9]{16,}['"]'''
 ```
 
+### Managing Ignore Patterns
+
+False positives occasionally occur when scanners match normal comments or example
+data. Add safe ignore patterns in `.gitleaks.toml` under `[allowlist.regexes]`.
+Each regex should narrowly target the text you want to skip:
+
+```toml
+[allowlist.regexes]
+regexes = [
+  '''example[_-]?key''',
+  '''TODO:[^"'=]*$'''
+]
+```
+
 ### **Security Validation Process**
 
 1. **Pre-commit**: detect-secrets baseline validation


### PR DESCRIPTION
## Summary
- narrow TODO/FIXME/XXX patterns in the secret scanning workflow
- update gitleaks configs with the stricter regex
- document how to manage ignore patterns

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68643f4bd5d0832bb32836c762677e62