### PR TITLE
Add constitutional_ai unit tests and cleanup placeholders

### DIFF
--- a/tests/integration/test_governance_synthesis_integration.py
+++ b/tests/integration/test_governance_synthesis_integration.py
@@ -17,33 +17,27 @@ class TestGovernancesynthesis:
     
     def test_component_initialization(self):
         """Test component can be initialized."""
-        # TODO: Implement actual initialization test
-        assert True, "Component initialization test placeholder"
+        pytest.skip("Not implemented")
     
     def test_component_basic_functionality(self):
         """Test basic component functionality."""
-        # TODO: Implement basic functionality tests
-        assert True, "Basic functionality test placeholder"
+        pytest.skip("Not implemented")
     
     def test_component_error_handling(self):
         """Test component error handling."""
-        # TODO: Implement error handling tests
-        assert True, "Error handling test placeholder"
+        pytest.skip("Not implemented")
     
     def test_component_edge_cases(self):
         """Test component edge cases."""
-        # TODO: Implement edge case tests
-        assert True, "Edge case test placeholder"
+        pytest.skip("Not implemented")
     
     def test_component_performance(self):
         """Test component performance characteristics."""
-        # TODO: Implement performance tests
-        assert True, "Performance test placeholder"
+        pytest.skip("Not implemented")
     
     def test_component_security(self):
         """Test component security aspects."""
-        # TODO: Implement security tests
-        assert True, "Security test placeholder"
+        pytest.skip("Not implemented")
 
 # Integration tests
 class TestGovernancesynthesisIntegration:
@@ -51,13 +45,11 @@ class TestGovernancesynthesisIntegration:
     
     def test_component_integration_with_dependencies(self):
         """Test component integration with its dependencies."""
-        # TODO: Implement integration tests
-        assert True, "Integration test placeholder"
+        pytest.skip("Not implemented")
     
     def test_component_data_flow(self):
         """Test data flow through the component."""
-        # TODO: Implement data flow tests
-        assert True, "Data flow test placeholder"
+        pytest.skip("Not implemented")
 
 # Performance tests
 class TestGovernancesynthesisPerformance:
@@ -65,10 +57,8 @@ class TestGovernancesynthesisPerformance:
     
     def test_component_latency(self):
         """Test component latency requirements."""
-        # TODO: Implement latency tests
-        assert True, "Latency test placeholder"
+        pytest.skip("Not implemented")
     
     def test_component_throughput(self):
         """Test component throughput requirements."""
-        # TODO: Implement throughput tests
-        assert True, "Throughput test placeholder"
+        pytest.skip("Not implemented")

--- a/tests/test_validation_service_utils.py
+++ b/tests/test_validation_service_utils.py
@@ -1,0 +1,62 @@
+import types
+import sys
+import re
+import time
+
+import pytest
+
+# Provide minimal schema stubs to satisfy imports
+schema_stub = types.ModuleType("services.core.constitutional_ai.ac_service.app.schemas")
+
+class ConstitutionalComplianceRequest:
+    def __init__(self, policy=None, validation_mode="comprehensive", include_reasoning=False, principles=None):
+        self.policy = policy or {}
+        self.validation_mode = validation_mode
+        self.include_reasoning = include_reasoning
+        self.principles = principles
+
+schema_stub.ConstitutionalComplianceRequest = ConstitutionalComplianceRequest
+sys.modules["services.core.constitutional_ai.ac_service.app.schemas"] = schema_stub
+
+# Prevent autouse fixtures from skipping tests due to missing async dependencies
+
+from services.core.constitutional_ai.ac_service.app.services.constitutional_validation_service import (
+    ConstitutionalValidationService,
+)
+
+
+@pytest.fixture()
+def service():
+    return ConstitutionalValidationService()
+
+
+def test_generate_validation_id(service):
+    vid = service._generate_validation_id({"policy": "demo"})
+    assert vid.startswith("VAL-")
+    parts = vid.split("-")
+    assert len(parts) == 3
+    assert re.fullmatch(r"\d+", parts[1])
+    assert len(parts[2]) == 8
+
+
+def test_get_rules_to_check_basic(service):
+    assert service._get_rules_to_check(None, "basic") == ["CONST-001", "CONST-003"]
+
+
+def test_get_rules_to_check_principles(service):
+    assert service._get_rules_to_check([{"rule_id": "CONST-004"}], "comprehensive") == ["CONST-004"]
+
+
+def test_calculate_average_severity_empty(service):
+    assert service._calculate_average_severity([]) == "unknown"
+
+
+def test_calculate_average_severity_mixed(service):
+    results = [{"severity": "high"}, {"severity": "critical"}]
+    assert service._calculate_average_severity(results) == "high"
+
+
+def test_generate_next_steps_noncompliant(service):
+    steps = service._generate_next_steps(False)
+    assert steps and steps[0].startswith("Review failed")
+


### PR DESCRIPTION
## Summary
- replace placeholder assertions with `pytest.skip` in governance synthesis tests
- add unit tests for `ConstitutionalValidationService`

## Testing
- `pytest tests/test_validation_service_utils.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68643f59e350832b8fd0e06f51f1a86e