### PR TITLE
Remove old underscore service dirs

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -37,3 +37,17 @@ for path in paths_to_add:
         path_str = str(path.absolute())
         if path_str not in sys.path:
             sys.path.insert(0, path_str)
+
+# Alias modules with underscores to corresponding hyphenated package names
+import importlib
+ALIASES = {
+    "services.core.constitutional_ai": "services.core.constitutional-ai",
+    "services.core.governance_synthesis": "services.core.governance-synthesis",
+    "services.core.governance_workflows": "services.core.governance-workflows",
+    "services.core.policy_governance": "services.core.policy-governance",
+}
+for alias, target in ALIASES.items():
+    try:
+        sys.modules[alias] = importlib.import_module(target)
+    except ModuleNotFoundError:
+        pass

--- a/core_algorithm_tester.py
+++ b/core_algorithm_tester.py
@@ -48,8 +48,7 @@ class CoreAlgorithmTester:
         try:
             # Test basic imports
             constitutional_dirs = [
-                "services/core/constitutional-ai",
-                "services/core/constitutional_ai"
+                "services/core/constitutional-ai"
             ]
             
             found_modules = []
@@ -113,8 +112,7 @@ class CoreAlgorithmTester:
         start_time = time.time()
         try:
             policy_dirs = [
-                "services/core/policy-governance",
-                "services/core/policy_governance"
+                "services/core/policy-governance"
             ]
             
             structure_analysis = {

--- a/services/core/constitutional_ai
+++ b/services/core/constitutional_ai
@@ -1,1 +1,0 @@
-constitutional-ai

--- a/services/core/governance_synthesis
+++ b/services/core/governance_synthesis
@@ -1,1 +1,0 @@
-governance-synthesis

--- a/services/core/governance_workflows
+++ b/services/core/governance_workflows
@@ -1,1 +1,0 @@
-governance-workflows

--- a/services/core/policy_governance
+++ b/services/core/policy_governance
@@ -1,1 +1,0 @@
-policy-governance


### PR DESCRIPTION
## Summary
- delete underscore service symlinks
- alias hyphenated packages in conftest
- clean up test helper paths

## Testing
- `pytest tests/unit/test_wina_enforcement_optimizer.py -q`
- `pytest tests/security/test_security_compliance.py -q`
- `pytest tests/integration/test_alphaevolve_acgs_simple.py::test_constitutional_council_scalability_config -q`

------
https://chatgpt.com/codex/tasks/task_e_68643f34746c832ba98d39a2b84aa7fd